### PR TITLE
Fix PDF export functionality: copy pdfBytes and use originalPdfBytes

### DIFF
--- a/app.js
+++ b/app.js
@@ -358,7 +358,7 @@ async function loadPDFFile(file) {
     
     // Convert to Uint8Array e SALVA in pdfBytes e originalPdfBytes
     pdfBytes = new Uint8Array(arrayBuffer);
-    originalPdfBytes = pdfBytes; // Riferimento allo stesso array
+    originalPdfBytes = new Uint8Array(pdfBytes); // Riferimento allo stesso array
     console.log('pdfBytes length:', pdfBytes.length);
     console.log('pdfBytes first 10 bytes:', Array.from(pdfBytes.slice(0, 10)));
     
@@ -671,7 +671,7 @@ async function exportPDF() {
     
     // Load original PDF with pdf-lib
     console.log('Loading PDF with pdf-lib...');
-    const pdfLibDoc = await PDFLib.PDFDocument.load(pdfBytes, { 
+    const pdfLibDoc = await PDFLib.PDFDocument.load(originalPdfBytes, { 
       ignoreEncryption: true,
       updateMetadata: false 
     });


### PR DESCRIPTION
## Issues Fixed
- PDF export button was not functioning properly
- pdfBytes was not being properly preserved for export

## Changes Made
1. Line 226: Changed `originalPdfBytes = pdfBytes;` to `originalPdfBytes = new Uint8Array(pdfBytes);` to create a proper copy of the PDF bytes instead of just a reference

2. Line 670 (approx): Changed `PDFDocument.load(pdfBytes,` to `PDFDocument.load(originalPdfBytes,` to ensure the original unmodified PDF is loaded during export

## Why This Fixes It
- Previously, originalPdfBytes was just a reference to pdfBytes, so both pointed to the same array
- By creating a new Uint8Array copy, we preserve the original PDF data separately
- Using originalPdfBytes during export ensures we're working with the unmodified original PDF